### PR TITLE
Fix the error trying to visualize the SQL model using SQLRSTableGroupVizualisation

### DIFF
--- a/src/SQL-Model-Vizualisation/SQLRSTableGroupVizualisation.class.st
+++ b/src/SQL-Model-Vizualisation/SQLRSTableGroupVizualisation.class.st
@@ -58,12 +58,10 @@ SQLRSTableGroupVizualisation >> collapseAll [
 SQLRSTableGroupVizualisation >> extractAssociationFor: nodeColumn with: allNodes [
 
 	| ref |
-	ref := (nodeColumn rawModel references
-		        select: [ :reference | 
-			        reference source isKindOf: FamixSQLForeignKeyConstraint ]
-		        thenCollect: [ :foreignRef | 
-			        foreignRef source foreignKeyColumnReferences collect: [ 
-				        :columnReference | columnReference column ] ]) flattened.
+	ref := (nodeColumn rawModel incomingForeignKeyReferences
+					collect: [ :foreignRef |
+						foreignRef foreignKeyConstraint columnReferences collect: [ 
+				   			:columnReference | columnReference column ] ]) flattened.
 	nodeColumn dependenciesToNodes:
 		(allNodes select: [ :aColumnNode | 
 			 ref includes: aColumnNode rawModel ])

--- a/src/SQL-Model/FamixSQLTableGroup.class.st
+++ b/src/SQL-Model/FamixSQLTableGroup.class.st
@@ -20,19 +20,6 @@ FamixSQLTableGroup class >> metamodel [
 	^ FamixSQLModel metamodel
 ]
 
-{ #category : #'as yet unclassified' }
-FamixSQLTableGroup >> inspectionTable: aBuilder [
-
-	<inspectorPresentationOrder: -1 title: 'MCD Tables'>
-	^ SpRoassal3InspectorPresenter new
-		  canvas: (SQLRSTableGroupVizualisation new
-				   collapseAll;
-				   sourceGroup: self;
-				   build;
-				   canvas);
-		  yourself
-]
-
 { #category : #testing }
 FamixSQLTableGroup >> isAssociation [
 


### PR DESCRIPTION
This PR is done from the work of @jeffsantos described in #10

Thanks for the proposed fix. 
As you depicted in the issue, there is still an issue with the visualization, we will investigate. 
The goal (for now) is to allow usage in Moose10 and 11 (but if it is too hard for our team it will probably go to Moose11 even if unstable with some backport on Moose10 for our industrial partner on this subject)